### PR TITLE
Let this demo use the stm32f4xx-hal instead of stm32f4 PAC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-features = false
 features = ["proto-ipv4", "socket-tcp"]
 
 [dependencies.stm32f4xx-hal]
-version = "0.2.2"
+version = "0.2.3"
 features = ["stm32f407", "rt"]
 
 [dependencies.stm32f4-smoltcp]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,17 +5,17 @@ authors = ["Adam Greig <adam@adamgreig.com>"]
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.5.7"
-cortex-m-rt = "0.6.4"
-panic-abort = "0.2.0"
+cortex-m = "0.5.8"
+cortex-m-rt = "0.6.5"
+panic-abort = "0.3.1"
 
 [dependencies.smoltcp]
 version = "0.5.0"
 default-features = false
 features = ["proto-ipv4", "socket-tcp"]
 
-[dependencies.stm32f4]
-version = "0.3.2"
+[dependencies.stm32f4xx-hal]
+version = "0.2.2"
 features = ["stm32f407", "rt"]
 
 [dependencies.stm32f4-smoltcp]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,16 @@
 
 extern crate panic_abort;
 
-use cortex_m_rt::{entry, exception};
+pub extern crate stm32f4xx_hal as hal;
+
 use cortex_m;
-use stm32f4::stm32f407;
+use cortex_m_rt::{entry, exception};
 use smoltcp;
-use stm32f4_smoltcp::{EthernetDevice, TDesRing, TDes, RDesRing, RDes, ETH_BUF_SIZE};
+use stm32f4_smoltcp::{EthernetDevice, RDes, RDesRing, TDes, TDesRing, ETH_BUF_SIZE};
+
+use self::hal::gpio::Speed::VeryHigh;
+use self::hal::prelude::*;
+use self::hal::*;
 
 mod network;
 
@@ -16,136 +21,39 @@ const ETH_NUM_RD: usize = 4;
 
 static mut TDESRING: TDesRing = TDesRing {
     td: &mut [TDes::new(); ETH_NUM_TD],
-    tbuf: &mut [[0; ETH_BUF_SIZE/4]; ETH_NUM_RD],
+    tbuf: &mut [[0; ETH_BUF_SIZE / 4]; ETH_NUM_RD],
     tdidx: 0,
 };
 
 static mut RDESRING: RDesRing = RDesRing {
     rd: &mut [RDes::new(); ETH_NUM_RD],
-    rbuf: &mut [[0; ETH_BUF_SIZE/4]; ETH_NUM_RD],
+    rbuf: &mut [[0; ETH_BUF_SIZE / 4]; ETH_NUM_RD],
     rdidx: 0,
 };
 
-fn rcc_init(p: &mut stm32f407::Peripherals) {
+fn rcc_init(p: &mut stm32::Peripherals) {
     let rcc = &p.RCC;
-    let flash = &p.FLASH;
     let syscfg = &p.SYSCFG;
-
-    // Ensure HSI is on and stable
-    rcc.cr.modify(|_, w| w.hsion().set_bit());
-    while rcc.cr.read().hsion().bit_is_clear() {}
-
-    // Set system clock to HSI
-    rcc.cfgr.modify(|_, w| w.sw().hsi());
-    while !rcc.cfgr.read().sws().is_hsi() {}
-
-    // Clear registers to reset value
-    rcc.cr.write(|w| w.hsion().set_bit());
-    rcc.cfgr.write(|w| unsafe { w.bits(0) });
-
-    // Configure PLL: 16MHz /8 *168 /2, source HSI
-    rcc.pllcfgr.write(|w| unsafe {
-        w.pllq().bits(4)
-         .pllsrc().hsi()
-         .pllp().div2()
-         .plln().bits(168)
-         .pllm().bits(8)
-    });
-    // Activate PLL
-    rcc.cr.modify(|_, w| w.pllon().set_bit());
-
-    // Set other clock domains: PPRE2 to /2, PPRE1 to /4, HPRE to /1
-    rcc.cfgr.modify(|_, w|
-        w.ppre2().div2()
-         .ppre1().div4()
-         .hpre().div1());
-
-    // Flash setup: I$ and D$ enabled, prefetch enabled, 5 wait states (OK for 3.3V at 168MHz)
-    flash.acr.write(|w| unsafe {
-        w.icen().set_bit()
-         .dcen().set_bit()
-         .prften().set_bit()
-         .latency().bits(5)
-    });
-
-    // Swap system clock to PLL
-    rcc.cfgr.modify(|_, w| w.sw().pll());
-    while !rcc.cfgr.read().sws().is_pll() {}
 
     // Set SYSCFG early to RMII mode
     rcc.apb2enr.modify(|_, w| w.syscfgen().enabled());
     syscfg.pmc.modify(|_, w| w.mii_rmii_sel().set_bit());
 
     // Set up peripheral clocks
-    rcc.ahb1enr.modify(|_, w|
-        w.gpioaen().enabled()
-         .gpioben().enabled()
-         .gpiocen().enabled()
-         .gpioden().enabled()
-         .gpioeen().enabled()
-         .gpiogen().enabled()
-         .crcen().enabled()
-         .ethmacrxen().enabled()
-         .ethmactxen().enabled()
-         .ethmacen().enabled()
-    );
-}
-
-fn gpio_init(p: &mut stm32f407::Peripherals) {
-    let gpioa = &p.GPIOA;
-    let gpiob = &p.GPIOB;
-    let gpioc = &p.GPIOC;
-    let gpioe = &p.GPIOE;
-
-    // Status LED
-    gpioe.moder.modify(|_, w| w.moder7().output());
-    gpioe.odr.modify(|_, w| w.odr7().clear_bit());
-
-    // Configure ethernet related GPIO:
-    // GPIOA 1, 2, 7
-    // GPIOC 1, 4, 5
-    // GPIOG 11, 13, 14
-    // All set to AF11 and very high speed.
-    gpioa.moder.modify(|_, w|
-        w.moder1().alternate()
-         .moder2().alternate()
-         .moder7().alternate());
-    gpiob.moder.modify(|_, w|
-         w.moder11().alternate()
-          .moder12().alternate()
-          .moder13().alternate());
-    gpioc.moder.modify(|_, w|
-        w.moder1().alternate()
-         .moder4().alternate()
-         .moder5().alternate());
-    gpioa.ospeedr.modify(|_, w|
-        w.ospeedr1().very_high_speed()
-         .ospeedr2().very_high_speed()
-         .ospeedr7().very_high_speed());
-    gpiob.ospeedr.modify(|_, w|
-        w.ospeedr11().very_high_speed()
-         .ospeedr12().very_high_speed()
-         .ospeedr13().very_high_speed());
-    gpioc.ospeedr.modify(|_, w|
-        w.ospeedr1().very_high_speed()
-         .ospeedr4().very_high_speed()
-         .ospeedr5().very_high_speed());
-    gpioa.afrl.modify(|_, w|
-        w.afrl1().af11()
-         .afrl2().af11()
-         .afrl7().af11());
-    gpiob.afrh.modify(|_, w|
-        w.afrh11().af11()
-         .afrh12().af11()
-         .afrh13().af11());
-    gpioc.afrl.modify(|_, w|
-        w.afrl1().af11()
-         .afrl4().af11()
-         .afrl5().af11());
+    rcc.ahb1enr.modify(|_, w| {
+        w.crcen()
+            .enabled()
+            .ethmacrxen()
+            .enabled()
+            .ethmactxen()
+            .enabled()
+            .ethmacen()
+            .enabled()
+    });
 }
 
 /// Set up the systick to provide a 1ms timebase
-fn systick_init(syst: &mut stm32f407::SYST) {
+fn systick_init(syst: &mut stm32::SYST) {
     syst.set_reload((168_000_000 / 8) / 1000);
     syst.clear_current();
     syst.set_clock_source(cortex_m::peripheral::syst::SystClkSource::External);
@@ -155,24 +63,66 @@ fn systick_init(syst: &mut stm32f407::SYST) {
 
 #[entry]
 fn main() -> ! {
-    let mut p = stm32f407::CorePeripherals::take().unwrap();
-    let mut dp = stm32f407::Peripherals::take().unwrap();
+    let mut p = stm32::CorePeripherals::take().unwrap();
+    let mut dp = stm32::Peripherals::take().unwrap();
 
     rcc_init(&mut dp);
-    gpio_init(&mut dp);
+
+    let rcc = dp.RCC;
 
     // Create ethernet driver
-    let mac_addr = smoltcp::wire::EthernetAddress::from_bytes(
-        &[0x02, 0x00, 0x00, 0x00, 0x00, 0x10]);
+    let mac_addr =
+        smoltcp::wire::EthernetAddress::from_bytes(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x10]);
     let mut ethdev = unsafe {
-        EthernetDevice::new(dp.ETHERNET_MAC, dp.ETHERNET_DMA, &mut RDESRING, &mut TDESRING, 0)
+        EthernetDevice::new(
+            dp.ETHERNET_MAC,
+            dp.ETHERNET_DMA,
+            &mut RDESRING,
+            &mut TDESRING,
+            0,
+        )
     };
-    ethdev.init(&mut dp.RCC, mac_addr.clone());
+
+    // Constrain clock registers
+    let rcc = rcc.constrain();
+
+    // Configure clock to 168 MHz (i.e. the maximum) and freeze it
+    let _ = rcc.cfgr.sysclk(168.mhz()).freeze();
+
+    // Status LED
+    let gpiod = dp.GPIOD.split();
+    let mut led = gpiod.pd13.into_push_pull_output();
+    led.set_low();
+
+    // Configure ethernet related GPIO:
+    // GPIOA 1, 2, 7
+    // GPIOB 11, 12, 13
+    // GPIOC 1, 4, 5
+    let gpioa = dp.GPIOA.split();
+    let gpiob = dp.GPIOB.split();
+    let gpioc = dp.GPIOC.split();
+
+    let _a1 = gpioa.pa1.set_speed(VeryHigh).into_alternate_af11();
+    let _a2 = gpioa.pa2.set_speed(VeryHigh).into_alternate_af11();
+    let _a7 = gpioa.pa7.set_speed(VeryHigh).into_alternate_af11();
+    let _b11 = gpiob.pb11.set_speed(VeryHigh).into_alternate_af11();
+    let _b12 = gpiob.pb12.set_speed(VeryHigh).into_alternate_af11();
+    let _b13 = gpiob.pb13.set_speed(VeryHigh).into_alternate_af11();
+    let _c1 = gpioc.pc1.set_speed(VeryHigh).into_alternate_af11();
+    let _c4 = gpioc.pc4.set_speed(VeryHigh).into_alternate_af11();
+    let _c5 = gpioc.pc5.set_speed(VeryHigh).into_alternate_af11();
+
+    // Initialise ethernet
+    ethdev.init(mac_addr.clone());
+
+    // Wait until we have a link
     ethdev.block_until_link();
 
+    // Change LED to high
+    led.set_high();
+
     // Create network interface
-    let ip_addr = smoltcp::wire::Ipv4Address::from_bytes(
-        &[192, 168, 2, 101]);
+    let ip_addr = smoltcp::wire::Ipv4Address::from_bytes(&[192, 168, 2, 101]);
     let ip_cidr = smoltcp::wire::Ipv4Cidr::new(ip_addr, 24);
     let cidr = smoltcp::wire::IpCidr::Ipv4(ip_cidr);
     network::init(ethdev, mac_addr, cidr);
@@ -189,5 +139,6 @@ fn main() -> ! {
 fn SysTick() {
     static mut TICKS: u32 = 0;
     *TICKS = *TICKS + 1;
+
     network::poll(*TICKS as i64);
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -77,7 +77,7 @@ pub fn init<'a>(eth_dev: EthernetDevice, mac_addr: EthernetAddress, ip_addr: IpC
 /// Poll network stack.
 ///
 /// Arrange for this function to be called frequently.
-pub fn poll(time_ms: i64) {
+pub fn poll(time_ms: u32) {
     // Unsafe required to access static mut NETWORK.
     // Since the entire poll is run in an interrupt-free context no
     // other access to NETWORK can occur.
@@ -105,7 +105,7 @@ pub fn poll(time_ms: i64) {
         }
 
         // Poll smoltcp
-        let timestamp = Instant::from_millis(time_ms);
+        let timestamp = Instant::from_millis(i64::from(time_ms));
         match NETWORK.eth_iface.as_mut().unwrap().poll(sockets, timestamp) {
             Ok(_) | Err(smoltcp::Error::Exhausted) => (),
             Err(_) => (),


### PR DESCRIPTION
This also changes the initialisation to use the safer routines provided
by the HAL. Other changes include more and fixed commentary and the use
of the status LED to indicate an Ethernet link.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>