### PR TITLE
The can_recv() predicate should actually be can_send() instead

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -92,7 +92,7 @@ pub fn poll(time_ms: i64) {
             if !socket.may_recv() && socket.may_send() {
                 socket.close();
             }
-            if socket.can_recv() {
+            if socket.can_send() {
                 write!(socket, "Hello, World!\r\n");
                 socket.close();
             }


### PR DESCRIPTION
can_recv() will be true in many stages of the TCP connection and thus
the example string be attempted to send multiple times. We're only
interested in doing so once the connection is fully established and the
remote ready to receive.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>