### PR TITLE
Enable LTO and opt-size = "s" for 10KiB (-30%) smaller firmware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ path = "../stm32f4-smoltcp"
 [profile.release]
 codegen-units = 1
 incremental = false
+debug = true
+opt-level = "s"
+lto = true


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>